### PR TITLE
fix(security): remove invalid Trivy configuration causing scan failures

### DIFF
--- a/trivy.yaml
+++ b/trivy.yaml
@@ -122,17 +122,6 @@ ignore:
   # Use .trivyignore file for vulnerability exceptions
   ignorefile: .trivyignore
 
-# Report configuration  
-report:
-  # Summary format
-  summary: true
-  
-  # Include dependency paths
-  dependency-tree: true
-  
-  # List all packages (including those without vulnerabilities)
-  list-all-pkgs: false
-
 # Integration settings
 integration:
   # GitHub Security Advisory integration


### PR DESCRIPTION
## Summary

This PR fixes a critical configuration issue in `trivy.yaml` that was preventing security scans from completing successfully in the CI/CD pipeline.

## Issue Resolved

### Trivy Configuration Error
- **Problem**: Security scans were failing with the error `invalid argument "" for "--report" flag: must be one of ["all" "summary"]`
- **Root Cause**: The `trivy.yaml` file contained an invalid `report:` section with nested configuration options that aren't supported by Trivy's configuration schema
- **Solution**: Removed the incompatible configuration section to allow scans to proceed with default settings

🤖 Generated with [Claude Code](https://claude.ai/code)